### PR TITLE
add parse cli key/value to public api

### DIFF
--- a/crates/dotrain/src/cli/mod.rs
+++ b/crates/dotrain/src/cli/mod.rs
@@ -4,10 +4,9 @@
 //! struct, enums that use `clap` derive macro to produce CLI commands, argument
 //! and options while underlying functions handle each scenario
 
-use std::error::Error;
 use std::path::PathBuf;
-use crate::parser::Rebind;
 use clap::{Parser, Subcommand, command};
+use crate::parser::{Rebind, parse_key_val};
 
 mod compose;
 mod rainconfig;
@@ -68,17 +67,6 @@ pub enum RainconfigInfo {
     Include,
     /// Prints info about 'subgraphs' field
     Subgraphs,
-}
-
-/// Parse a single key-value pair
-fn parse_key_val(key_value_pair: &str) -> Result<Rebind, Box<dyn Error + Send + Sync + 'static>> {
-    let pos = key_value_pair
-        .find('=')
-        .ok_or_else(|| format!("invalid key=value: no `=` found in `{key_value_pair}`"))?;
-    Ok(Rebind(
-        key_value_pair[..pos].to_owned(),
-        key_value_pair[pos + 1..].to_owned(),
-    ))
 }
 
 /// Dispatches the CLI call based on the given options and commands

--- a/crates/dotrain/src/cli/mod.rs
+++ b/crates/dotrain/src/cli/mod.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 use clap::{Parser, Subcommand, command};
-use crate::parser::{Rebind, parse_key_val};
+use crate::parser::{Rebind, parse_cli_key_val};
 
 mod compose;
 mod rainconfig;
@@ -41,7 +41,7 @@ pub struct Compose {
     #[arg(short, long)]
     entrypoint: Vec<String>,
     /// rebinds items with new literal values
-    #[arg(short, long, value_parser = parse_key_val)]
+    #[arg(short, long, value_parser = parse_cli_key_val)]
     bind: Option<Vec<Rebind>>,
     /// Path to the rainconfig json file that contains configurations,
     /// if provided will be used to when composing the .rain, see

--- a/crates/dotrain/src/parser/mod.rs
+++ b/crates/dotrain/src/parser/mod.rs
@@ -283,9 +283,9 @@ mod tests {
     use crate::parser::*;
 
     #[test]
-    fn test_parse_cli_key_val() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    fn test_parse_cli_key_val() -> anyhow::Result<()> {
         let key_value_pair = "key=value";
-        let result = parse_cli_key_val(key_value_pair)?;
+        let result = parse_cli_key_val(key_value_pair).unwrap();
 
         assert_eq!(result.0, "key");
         assert_eq!(result.1, "value");

--- a/crates/dotrain/src/parser/mod.rs
+++ b/crates/dotrain/src/parser/mod.rs
@@ -265,7 +265,9 @@ pub(crate) fn deep_read_quote<'a>(
     }
 }
 
-/// Parse a single key-value pair from cli arg
+/// Parse a single key-value pair from cli arg.
+/// This is implemented from examples in clap crate docs:
+/// https://docs.rs/clap/latest/clap/builder/struct.ValueParser.html#example-1
 pub fn parse_cli_key_val(
     key_value_pair: &str,
 ) -> Result<Rebind, Box<dyn std::error::Error + Send + Sync + 'static>> {

--- a/crates/dotrain/src/parser/mod.rs
+++ b/crates/dotrain/src/parser/mod.rs
@@ -265,6 +265,19 @@ pub(crate) fn deep_read_quote<'a>(
     }
 }
 
+/// Parse a single key-value pair from cli arg
+pub fn parse_key_val(
+    key_value_pair: &str,
+) -> Result<Rebind, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let pos = key_value_pair
+        .find('=')
+        .ok_or_else(|| format!("invalid key=value: no `=` found in `{key_value_pair}`"))?;
+    Ok(Rebind(
+        key_value_pair[..pos].to_owned(),
+        key_value_pair[pos + 1..].to_owned(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::parser::*;

--- a/crates/dotrain/src/parser/mod.rs
+++ b/crates/dotrain/src/parser/mod.rs
@@ -266,7 +266,7 @@ pub(crate) fn deep_read_quote<'a>(
 }
 
 /// Parse a single key-value pair from cli arg
-pub fn parse_key_val(
+pub fn parse_cli_key_val(
     key_value_pair: &str,
 ) -> Result<Rebind, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let pos = key_value_pair

--- a/crates/dotrain/src/parser/mod.rs
+++ b/crates/dotrain/src/parser/mod.rs
@@ -283,6 +283,17 @@ mod tests {
     use crate::parser::*;
 
     #[test]
+    fn test_parse_cli_key_val() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let key_value_pair = "key=value";
+        let result = parse_cli_key_val(key_value_pair)?;
+        
+        assert_eq!(result.0, "key");
+        assert_eq!(result.1, "value");
+
+        Ok(())
+    }
+
+    #[test]
     fn test_inclusive_parse() -> anyhow::Result<()> {
         let text = r"abcd eb
         qkbjh (aoib 124b)";

--- a/crates/dotrain/src/parser/mod.rs
+++ b/crates/dotrain/src/parser/mod.rs
@@ -286,7 +286,7 @@ mod tests {
     fn test_parse_cli_key_val() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let key_value_pair = "key=value";
         let result = parse_cli_key_val(key_value_pair)?;
-        
+
         assert_eq!(result.0, "key");
         assert_eq!(result.1, "value");
 


### PR DESCRIPTION
The `parse_cli_key_val` is a method that needs to be used across repos, mainly when trying to add bindings cli option for a cli app other that current dotrain cli app.
so it is moved into public api and added tests for it

todo: 
- [x]   move `parse_cli_key_val()` fn to public API
- [x]   add tests for `parse_cli_key_val()`