### PR TITLE
decimals support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ rainconfig.json
 /old
 result
 docs
+proptest-regressions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "js-sys",
  "magic_string",
  "once_cell",
+ "proptest",
  "rain-metadata",
  "regex",
  "serde",

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cargo add dotrain
 
 ### Features
 - `cli`: A [clap](https://docs.rs/clap/latest/clap/) based module (CLI app) for functionalities of this library, this features is required for building the **binary**
-- `js-api`: includes wrappers around main structs and functionalities to provide an API through [wasm-bindgen](https://rustwasm.github.io/docs/wasm-bindgen/) (this feature is always enabled when building for wasm family targets)
+- `js-api`: includes wrappers around main structs and functionalities to provide an API through [wasm-bindgen](https://rustwasm.github.io/docs/wasm-bindgen/)
 
 <br>
 

--- a/crates/dotrain/Cargo.toml
+++ b/crates/dotrain/Cargo.toml
@@ -51,5 +51,8 @@ tsify = { version = "0.4.5", default-features = false, features = ["js", "wasm-b
 [lints.clippy]
 all = "warn"
 
+[dev-dependencies]
+proptest = "1.4.0"
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1115,6 +1115,21 @@ _: opcode-1(0xabcd "something.else");
 _: opcode-1(0xabcd "something.else");"#;
         assert_eq!(rainlang_text, expected_rainlang);
 
+        let dotrain_text = r#"
+        some 
+        front 
+        matter
+---
+/* this is test */
+
+#exp-binding
+_: opcode-1(12.34e6 123.123);
+"#;
+        let rainlang_text = RainDocument::compose_text(dotrain_text, &["exp-binding"], None, None)?;
+        let expected_rainlang = r#"/* 0. exp-binding */ 
+_: opcode-1(12.34e6 123.123);"#;
+        assert_eq!(rainlang_text, expected_rainlang);
+
         Ok(())
     }
 

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1406,12 +1406,12 @@ _: opcode-1(0xabcd 456);
         Ok(())
     }
 
-    /// we need [crate::types::patterns::NUMERIC_PATTERN] but
+    /// need [crate::types::patterns::E_PATTERN] and [crate::types::patterns::INT_PATTERN] but
     /// without anchors/boundries which proptest doesnt support
-    const PATTERN: &str = r"0x[0-9a-fA-F]+|[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
+    const PATTERN: &str = r"[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
         #[test]
-        fn test_fuzz_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {
+        fn test_fuzz_num_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {
             let dotrain_text = format!("
 some 
 front 
@@ -1423,25 +1423,10 @@ matter
 _: opcode-1<{} {}>({} {});
 ", a, b, c, d);
 
-            let result = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None);
+            let rainlang_text = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None)?;
+            let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", a, b, c, d);
 
-            // since fuzzer can produce odd length hex literals, the
-            // only acceptable compose error is ErrorCode::OddLenHex
-            match result {
-                Ok(rainlang_text) => {
-                    let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", a, b, c, d);
-                    assert_eq!(rainlang_text, expected_rainlang);
-                },
-                Err(e) => {
-                    if let ComposeError::Problems(problems) = e {
-                        for p in problems {
-                            assert_eq!(p.code, ErrorCode::OddLenHex);
-                        }
-                    } else {
-                        panic!("failed fuzz tests!")
-                    }
-                }
-            }
+            assert_eq!(rainlang_text, expected_rainlang);
         }
     }
 }

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -514,7 +514,7 @@ mod tests {
     use crate::error::ErrorCode;
     use crate::parser::Rebind;
     use futures::executor::block_on;
-    use proptest::proptest;
+    use proptest::{proptest, test_runner::Config};
     use rain_metadata::{
         types::authoring::v1::{AuthoringMetaItem, AuthoringMeta},
         NPE2Deployer,
@@ -1410,8 +1410,9 @@ _: opcode-1(0xabcd 456);
     /// without anchors/boundries (in this case they are ^ and $) which proptest doesnt support
     const PATTERN: &str = r"[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
-        #![proptest_config(proptest::test_runner::Config {
-            cases: 999, .. proptest::test_runner::Config::default()
+        #![proptest_config(Config {
+            cases: 999,
+            ..Config::default()
         })]
         #[test]
         fn test_fuzz_num_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1406,12 +1406,12 @@ _: opcode-1(0xabcd 456);
         Ok(())
     }
 
-    /// we need [crate::types::patterns::NUMERIC_PATTERN] but without anchors/boundries which proptest doesnt support
-    static NUMERIC_PATTERN: &str =
-        r"0x[0-9a-fA-F]+|[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
+    /// we need [crate::types::patterns::NUMERIC_PATTERN] but
+    /// without anchors/boundries which proptest doesnt support
+    static PATTERN: &str = r"0x[0-9a-fA-F]+|[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
         #[test]
-        fn test_fuzz_literals_compose(a in NUMERIC_PATTERN, b in NUMERIC_PATTERN, c in NUMERIC_PATTERN, d in NUMERIC_PATTERN) {
+        fn test_fuzz_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {
             let dotrain_text = format!(r#"
 some 
 front 
@@ -1425,7 +1425,7 @@ _: opcode-1<{} {}>({} {});
 
             let result = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None);
 
-            // since fuzzer can produce odd length hex literals, the only 
+            // since fuzzer can produce odd length hex literals, the only
             // acceptable compose error is if it is a ErrorCode::OddLenHex
             match result {
                 Ok(rainlang_text) => {

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1408,11 +1408,11 @@ _: opcode-1(0xabcd 456);
 
     /// we need [crate::types::patterns::NUMERIC_PATTERN] but
     /// without anchors/boundries which proptest doesnt support
-    static PATTERN: &str = r"0x[0-9a-fA-F]+|[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
+    const PATTERN: &str = r"0x[0-9a-fA-F]+|[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
         #[test]
         fn test_fuzz_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {
-            let dotrain_text = format!(r#"
+            let dotrain_text = format!("
 some 
 front 
 matter
@@ -1421,12 +1421,12 @@ matter
 
 #exp-binding
 _: opcode-1<{} {}>({} {});
-"#, a, b, c, d);
+", a, b, c, d);
 
             let result = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None);
 
-            // since fuzzer can produce odd length hex literals, the only
-            // acceptable compose error is if it is a ErrorCode::OddLenHex
+            // since fuzzer can produce odd length hex literals, the
+            // only acceptable compose error is ErrorCode::OddLenHex
             match result {
                 Ok(rainlang_text) => {
                     let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", a, b, c, d);

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1407,7 +1407,7 @@ _: opcode-1(0xabcd 456);
     }
 
     /// need [crate::types::patterns::E_PATTERN] and [crate::types::patterns::INT_PATTERN] but
-    /// without anchors/boundries which proptest doesnt support
+    /// without anchors/boundries (in this case they are ^ and $) which proptest doesnt support
     const PATTERN: &str = r"[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
         #[test]
@@ -1419,12 +1419,15 @@ matter
 ---
 /* this is test */
 
+#literal-a {}
+#literal-b {}
+
 #exp-binding
-_: opcode-1<{} {}>({} {});
+_: opcode-1<{} literal-a>(literal-b {});
 ", a, b, c, d);
 
             let rainlang_text = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None)?;
-            let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", a, b, c, d);
+            let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", c, a, b, d);
 
             assert_eq!(rainlang_text, expected_rainlang);
         }

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1410,6 +1410,9 @@ _: opcode-1(0xabcd 456);
     /// without anchors/boundries (in this case they are ^ and $) which proptest doesnt support
     const PATTERN: &str = r"[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
+        #![proptest_config(proptest::test_runner::Config {
+            cases: 999, .. proptest::test_runner::Config::default()
+        })]
         #[test]
         fn test_fuzz_num_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {
             let dotrain_text = format!("

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1432,8 +1432,7 @@ matter
 #literal-b {}
 
 #exp-binding
-_: opcode-1<{} literal-a>(literal-b {});
-", a[0], b[0], e1, e2);
+_: opcode-1<{} literal-a>(literal-b {});", a[0], b[0], e1, e2);
 
             let rainlang_text = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None)?;
             let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", e1, a[0], b[0], e2);

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1406,7 +1406,7 @@ _: opcode-1(0xabcd 456);
         Ok(())
     }
 
-    /// need [crate::types::patterns::E_PATTERN] and [crate::types::patterns::INT_PATTERN] but
+    /// [crate::types::patterns::E_PATTERN] and [crate::types::patterns::INT_PATTERN] but
     /// without anchors/boundries (in this case they are ^ and $) which proptest doesnt support
     const PATTERN: &str = r"[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {

--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1406,16 +1406,21 @@ _: opcode-1(0xabcd 456);
         Ok(())
     }
 
-    /// [crate::types::patterns::E_PATTERN] and [crate::types::patterns::INT_PATTERN] but
-    /// without anchors/boundries (in this case they are ^ and $) which proptest doesnt support
-    const PATTERN: &str = r"[0-9]+(\.[0-9]+)?|[1-9][0-9]*(\.[0-9]+)?e[0-9]+";
     proptest! {
         #![proptest_config(Config {
             cases: 999,
             ..Config::default()
         })]
         #[test]
-        fn test_fuzz_num_literals_compose(a in PATTERN, b in PATTERN, c in PATTERN, d in PATTERN) {
+        fn test_fuzz_num_literals_compose(
+            a in [0f64..f64::MAX],
+            b in [0f64..f64::MAX],
+            c in [0f64..f64::MAX],
+            d in [0f64..f64::MAX],
+        ) {
+            let e1 = format!("{:e}", c[0]);
+            let e2 = format!("{:e}", d[0]);
+
             let dotrain_text = format!("
 some 
 front 
@@ -1428,10 +1433,10 @@ matter
 
 #exp-binding
 _: opcode-1<{} literal-a>(literal-b {});
-", a, b, c, d);
+", a[0], b[0], e1, e2);
 
             let rainlang_text = RainDocument::compose_text(&dotrain_text, &["exp-binding"], None, None)?;
-            let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", c, a, b, d);
+            let expected_rainlang = format!("/* 0. exp-binding */ \n_: opcode-1<{} {}>({} {});", e1, a[0], b[0], e2);
 
             assert_eq!(rainlang_text, expected_rainlang);
         }

--- a/crates/dotrain/src/parser/raindocument/logic.rs
+++ b/crates/dotrain/src/parser/raindocument/logic.rs
@@ -7,7 +7,7 @@ use super::super::{
     super::error::{Error, ErrorCode},
     deep_read_quote, exclusive_parse, fill_in, inclusive_parse, is_consumable,
     rainlangdocument::RainlangDocument,
-    to_u256, tracked_trim,
+    tracked_trim,
 };
 
 impl RainDocument {
@@ -260,8 +260,7 @@ impl RainDocument {
         } else {
             let items = exclusive_parse(text, &WS_PATTERN, 0, false);
             if items.len() == 1 && NUMERIC_PATTERN.is_match(&items[0].0) {
-                let is_out_of_range = to_u256(&items[0].0).is_err();
-                Some((items[0].0.clone(), 2, is_out_of_range))
+                Some((items[0].0.clone(), 2, false))
             } else {
                 None
             }

--- a/crates/dotrain/src/parser/raindocument/mod.rs
+++ b/crates/dotrain/src/parser/raindocument/mod.rs
@@ -298,7 +298,7 @@ mod tests {
 
         let text = " \n 99999e99999 \n";
         let result = RainDocument::is_literal(text);
-        assert_eq!(result, Some(("99999e99999".to_owned(), 2, true)));
+        assert_eq!(result, Some(("99999e99999".to_owned(), 2, false)));
 
         let text = "\" some\n literal  \nvalue\t\n \"";
         let result = RainDocument::is_literal(text);

--- a/crates/dotrain/src/parser/rainlangdocument/logic.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/logic.rs
@@ -677,19 +677,7 @@ impl RainlangDocument {
                 self.problems
                     .push(ErrorCode::ExpectedOpeningParen.to_problem(vec![], next_pos));
             }
-        } else if STRING_LITERAL_PATTERN.is_match(next) || SUB_PARSER_LITERAL_PATTERN.is_match(next)
-        {
-            self.update_state(Node::Literal(Literal {
-                value: next.to_owned(),
-                position: next_pos,
-                lhs_alias: None,
-                id: None,
-            }))?;
-        } else if NUMERIC_PATTERN.is_match(next) {
-            if HEX_PATTERN.is_match(next) && next.len() % 2 == 1 {
-                self.problems
-                    .push(ErrorCode::OddLenHex.to_problem(vec![], next_pos));
-            }
+        } else if LITERAL_PATTERN.is_match(next) {
             self.update_state(Node::Literal(Literal {
                 value: next.to_owned(),
                 position: next_pos,

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -522,7 +522,7 @@ mod tests {
             },
         ]);
 
-        let text = "opcode<12.2 56>(";
+        let text = "opcode<12 56>(";
         let consumed_count = rl.consume(text, 10, &namespace, &authoring_meta)?;
         let mut expected_state_nodes = vec![Node::Opcode(Opcode {
             opcode: OpcodeDetails {
@@ -533,11 +533,49 @@ mod tests {
             operand: None,
             output: None,
             position: [10, 0],
-            parens: [25, 0],
+            parens: [23, 0],
             inputs: vec![],
             lhs_alias: None,
             operand_args: Some(OperandArg {
-                position: [16, 25],
+                position: [16, 23],
+                args: vec![
+                    OperandArgItem {
+                        value: Some("12".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [17, 19],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                    OperandArgItem {
+                        value: Some("56".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [20, 22],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                ],
+            }),
+        })];
+        assert_eq!(consumed_count, text.len());
+        assert_eq!(rl.state.nodes, expected_state_nodes);
+
+        let text = "opcode<12.2 2.5e16>(";
+        rl.state.depth -= 1;
+        let consumed_count = rl.consume(text, 10, &namespace, &authoring_meta)?;
+        expected_state_nodes.push(Node::Opcode(Opcode {
+            opcode: OpcodeDetails {
+                name: "opcode".to_owned(),
+                description: String::new(),
+                position: [10, 16],
+            },
+            operand: None,
+            output: None,
+            position: [10, 0],
+            parens: [29, 0],
+            inputs: vec![],
+            lhs_alias: None,
+            operand_args: Some(OperandArg {
+                position: [16, 29],
                 args: vec![
                     OperandArgItem {
                         value: Some("12.2".to_owned()),
@@ -547,15 +585,15 @@ mod tests {
                         binding_id: None,
                     },
                     OperandArgItem {
-                        value: Some("56".to_owned()),
+                        value: Some("2.5e16".to_owned()),
                         name: "operand arg".to_owned(),
-                        position: [22, 24],
+                        position: [22, 28],
                         description: String::new(),
                         binding_id: None,
                     },
                 ],
             }),
-        })];
+        }));
         assert_eq!(consumed_count, text.len());
         assert_eq!(rl.state.nodes, expected_state_nodes);
 
@@ -577,6 +615,44 @@ mod tests {
             operand_args: None,
         }));
         assert_eq!(consumed_count, "another-opcode(".len());
+        assert_eq!(rl.state.nodes, expected_state_nodes);
+
+        let text = "another-opcode-2<\n  0x1f\n  87>(\n  0xabcef1234\n)";
+        rl.state.depth -= 1;
+        let consumed_count = rl.consume(text, 77, &namespace, &authoring_meta)?;
+        expected_state_nodes.push(Node::Opcode(Opcode {
+            opcode: OpcodeDetails {
+                name: "another-opcode-2".to_owned(),
+                description: String::new(),
+                position: [77, 93],
+            },
+            operand: None,
+            output: None,
+            position: [77, 0],
+            parens: [107, 0],
+            inputs: vec![],
+            lhs_alias: None,
+            operand_args: Some(OperandArg {
+                position: [93, 107],
+                args: vec![
+                    OperandArgItem {
+                        value: Some("0x1f".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [97, 101],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                    OperandArgItem {
+                        value: Some("87".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [104, 106],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                ],
+            }),
+        }));
+        assert_eq!(consumed_count, "another-opcode-2<\n  0x1f\n  87>(".len());
         assert_eq!(rl.state.nodes, expected_state_nodes);
 
         let text = "another-opcode-2<\n  0x1f\n  87.3e2>(\n  0xabcef1234\n)";

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -254,7 +254,6 @@ mod tests {
                 ],
             }),
         };
-
         assert_eq!(consumed_count, exp.len());
         assert_eq!(op, expected_op);
 

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -508,7 +508,10 @@ mod tests {
                 ],
             }),
         }));
-        assert_eq!(consumed_count, "another-opcode-2<\n  0x1f\n  87.3e2>(".len());
+        assert_eq!(
+            consumed_count,
+            "another-opcode-2<\n  0x1f\n  87.3e2>(".len()
+        );
         assert_eq!(rl.state.nodes, expected_state_nodes);
 
         Ok(())

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -238,7 +238,7 @@ mod tests {
                         binding_id: None,
                     },
                     OperandArgItem {
-                        value: Some("56.9".to_owned()),
+                        value: Some("56".to_owned()),
                         name: "operand arg".to_owned(),
                         position: [12, 14],
                         description: String::new(),
@@ -434,6 +434,59 @@ mod tests {
                         value: Some(r#""56.abcd""#.to_owned()),
                         name: "operand arg".to_owned(),
                         position: [15, 24],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                ],
+            }),
+        };
+
+        assert_eq!(consumed_count, exp.len());
+        assert_eq!(op, expected_op);
+
+        let exp = r#"<12.3 2.5e16>"#;
+        let mut op = Opcode {
+            opcode: OpcodeDetails {
+                name: "opc".to_owned(),
+                description: String::new(),
+                position: [5, 8],
+            },
+            operand: None,
+            output: None,
+            position: [5, 0],
+            parens: [0, 0],
+            inputs: vec![],
+            lhs_alias: None,
+            operand_args: None,
+        };
+
+        let consumed_count = rl.process_operand(exp, 8, &mut op, &namespace);
+        let expected_op = Opcode {
+            opcode: OpcodeDetails {
+                name: "opc".to_owned(),
+                description: String::new(),
+                position: [5, 8],
+            },
+            operand: None,
+            output: None,
+            position: [5, 0],
+            parens: [0, 0],
+            inputs: vec![],
+            lhs_alias: None,
+            operand_args: Some(OperandArg {
+                position: [8, 21],
+                args: vec![
+                    OperandArgItem {
+                        value: Some("12.3".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [9, 13],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                    OperandArgItem {
+                        value: Some("2.5e16".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [14, 20],
                         description: String::new(),
                         binding_id: None,
                     },

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -198,7 +198,7 @@ mod tests {
     fn test_process_operand_method() -> anyhow::Result<()> {
         let mut rl = RainlangDocument::new();
         let namespace = HashMap::new();
-        let exp = r#"<"12." 56>"#;
+        let exp = r#"<"12." 56.9>"#;
         let mut op = Opcode {
             opcode: OpcodeDetails {
                 name: "opc".to_owned(),
@@ -228,7 +228,7 @@ mod tests {
             inputs: vec![],
             lhs_alias: None,
             operand_args: Some(OperandArg {
-                position: [8, 18],
+                position: [8, 20],
                 args: vec![
                     OperandArgItem {
                         value: Some(r#""12.""#.to_owned()),
@@ -238,9 +238,9 @@ mod tests {
                         binding_id: None,
                     },
                     OperandArgItem {
-                        value: Some("56".to_owned()),
+                        value: Some("56.9".to_owned()),
                         name: "operand arg".to_owned(),
-                        position: [15, 17],
+                        position: [15, 19],
                         description: String::new(),
                         binding_id: None,
                     },
@@ -416,7 +416,7 @@ mod tests {
             },
         ]);
 
-        let text = "opcode<12 56>(";
+        let text = "opcode<12.2 56>(";
         let consumed_count = rl.consume(text, 10, &namespace, &authoring_meta)?;
         let mut expected_state_nodes = vec![Node::Opcode(Opcode {
             opcode: OpcodeDetails {
@@ -427,23 +427,23 @@ mod tests {
             operand: None,
             output: None,
             position: [10, 0],
-            parens: [23, 0],
+            parens: [25, 0],
             inputs: vec![],
             lhs_alias: None,
             operand_args: Some(OperandArg {
-                position: [16, 23],
+                position: [16, 25],
                 args: vec![
                     OperandArgItem {
-                        value: Some("12".to_owned()),
+                        value: Some("12.2".to_owned()),
                         name: "operand arg".to_owned(),
-                        position: [17, 19],
+                        position: [17, 21],
                         description: String::new(),
                         binding_id: None,
                     },
                     OperandArgItem {
                         value: Some("56".to_owned()),
                         name: "operand arg".to_owned(),
-                        position: [20, 22],
+                        position: [22, 24],
                         description: String::new(),
                         binding_id: None,
                     },
@@ -473,7 +473,7 @@ mod tests {
         assert_eq!(consumed_count, "another-opcode(".len());
         assert_eq!(rl.state.nodes, expected_state_nodes);
 
-        let text = "another-opcode-2<\n  0x1f\n  87>(\n  0xabcef1234\n)";
+        let text = "another-opcode-2<\n  0x1f\n  87.3e2>(\n  0xabcef1234\n)";
         rl.state.depth -= 1;
         let consumed_count = rl.consume(text, 77, &namespace, &authoring_meta)?;
         expected_state_nodes.push(Node::Opcode(Opcode {
@@ -485,11 +485,11 @@ mod tests {
             operand: None,
             output: None,
             position: [77, 0],
-            parens: [107, 0],
+            parens: [111, 0],
             inputs: vec![],
             lhs_alias: None,
             operand_args: Some(OperandArg {
-                position: [93, 107],
+                position: [93, 111],
                 args: vec![
                     OperandArgItem {
                         value: Some("0x1f".to_owned()),
@@ -499,16 +499,16 @@ mod tests {
                         binding_id: None,
                     },
                     OperandArgItem {
-                        value: Some("87".to_owned()),
+                        value: Some("87.3e2".to_owned()),
                         name: "operand arg".to_owned(),
-                        position: [104, 106],
+                        position: [104, 110],
                         description: String::new(),
                         binding_id: None,
                     },
                 ],
             }),
         }));
-        assert_eq!(consumed_count, "another-opcode-2<\n  0x1f\n  87>(".len());
+        assert_eq!(consumed_count, "another-opcode-2<\n  0x1f\n  87.3e2>(".len());
         assert_eq!(rl.state.nodes, expected_state_nodes);
 
         Ok(())

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -196,31 +196,38 @@ mod tests {
 
     #[test]
     fn test_process_operand_method() -> anyhow::Result<()> {
+        fn get_op() -> Opcode {
+            Opcode {
+                opcode: OpcodeDetails {
+                    name: "opc".to_owned(),
+                    description: String::new(),
+                    position: [5, 8],
+                },
+                operand: None,
+                output: None,
+                position: [5, 0],
+                parens: [0, 0],
+                inputs: vec![],
+                lhs_alias: None,
+                operand_args: None,
+            }
+        }
+        fn get_op_details() -> OpcodeDetails {
+            OpcodeDetails {
+                name: "opc".to_owned(),
+                description: String::new(),
+                position: [5, 8],
+            }
+        }
+
         let mut rl = RainlangDocument::new();
         let namespace = HashMap::new();
-        let exp = r#"<12 56>"#;
-        let mut op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
-            operand: None,
-            output: None,
-            position: [5, 0],
-            parens: [0, 0],
-            inputs: vec![],
-            lhs_alias: None,
-            operand_args: None,
-        };
 
+        let exp = r#"<12 56>"#;
+        let mut op = get_op();
         let consumed_count = rl.process_operand(exp, 8, &mut op, &namespace);
         let expected_op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
+            opcode: get_op_details(),
             operand: None,
             output: None,
             position: [5, 0],
@@ -253,28 +260,10 @@ mod tests {
 
         let exp =
             r#"<0xa5 "some string literal " some-literal-binding "some other string literal ">"#;
-        let mut op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opcode".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
-            operand: None,
-            output: None,
-            position: [5, 0],
-            parens: [0, 0],
-            inputs: vec![],
-            lhs_alias: None,
-            operand_args: None,
-        };
-
+        let mut op = get_op();
         let consumed_count = rl.process_operand(exp, 8, &mut op, &namespace);
         let expected_op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opcode".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
+            opcode: get_op_details(),
             operand: None,
             output: None,
             position: [5, 0],
@@ -319,28 +308,10 @@ mod tests {
         assert_eq!(op, expected_op);
 
         let exp = "<1\n0xf2\n69   32 [some sub parser literal]>";
-        let mut op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
-            operand: None,
-            output: None,
-            position: [5, 0],
-            parens: [0, 0],
-            inputs: vec![],
-            lhs_alias: None,
-            operand_args: None,
-        };
-
+        let mut op = get_op();
         let consumed_count = rl.process_operand(exp, 15, &mut op, &namespace);
         let expected_op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
+            opcode: get_op_details(),
             operand: None,
             output: None,
             position: [5, 0],
@@ -392,28 +363,10 @@ mod tests {
         assert_eq!(op, expected_op);
 
         let exp = r#"<"12." "56.abcd">"#;
-        let mut op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
-            operand: None,
-            output: None,
-            position: [5, 0],
-            parens: [0, 0],
-            inputs: vec![],
-            lhs_alias: None,
-            operand_args: None,
-        };
-
+        let mut op = get_op();
         let consumed_count = rl.process_operand(exp, 8, &mut op, &namespace);
         let expected_op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
+            opcode: get_op_details(),
             operand: None,
             output: None,
             position: [5, 0],
@@ -440,33 +393,14 @@ mod tests {
                 ],
             }),
         };
-
         assert_eq!(consumed_count, exp.len());
         assert_eq!(op, expected_op);
 
         let exp = r#"<12.3 2.5e16>"#;
-        let mut op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
-            operand: None,
-            output: None,
-            position: [5, 0],
-            parens: [0, 0],
-            inputs: vec![],
-            lhs_alias: None,
-            operand_args: None,
-        };
-
+        let mut op = get_op();
         let consumed_count = rl.process_operand(exp, 8, &mut op, &namespace);
         let expected_op = Opcode {
-            opcode: OpcodeDetails {
-                name: "opc".to_owned(),
-                description: String::new(),
-                position: [5, 8],
-            },
+            opcode: get_op_details(),
             operand: None,
             output: None,
             position: [5, 0],
@@ -493,7 +427,6 @@ mod tests {
                 ],
             }),
         };
-
         assert_eq!(consumed_count, exp.len());
         assert_eq!(op, expected_op);
 

--- a/crates/dotrain/src/types/patterns.rs
+++ b/crates/dotrain/src/types/patterns.rs
@@ -22,8 +22,9 @@ pub static WORD_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-z][0-9a-z-]
 pub static HASH_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]{64}$").unwrap());
 
 /// numeric pattern
-pub static NUMERIC_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]+$|^\d+(\.\d+)?$|^[1-9]\d*(\.\d+)?e\d+$").unwrap());
+pub static NUMERIC_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^0x[0-9a-fA-F]+$|^[0-9]+(\.[0-9]+)?$|^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$").unwrap()
+});
 
 /// string literal pattern
 pub static STRING_LITERAL_PATTERN: Lazy<Regex> =
@@ -36,7 +37,7 @@ pub static SUB_PARSER_LITERAL_PATTERN: Lazy<Regex> =
 /// literal pattern (numeric + string literal + sub parser)
 pub static LITERAL_PATTERN: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"^0x[0-9a-fA-F]+$|^\d+(\.\d+)?$|^[1-9]\d*(\.\d+)?e\d+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$"#,
+        r#"^0x[0-9a-fA-F]+$|^[0-9]+(\.[0-9]+)?$|^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$"#,
     )
     .unwrap()
 });
@@ -45,10 +46,11 @@ pub static LITERAL_PATTERN: Lazy<Regex> = Lazy::new(|| {
 pub static HEX_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]+$").unwrap());
 
 /// e numberic pattern
-pub static E_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[1-9]\d*(\.\d+)?e\d+$").unwrap());
+pub static E_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$").unwrap());
 
 /// Integer pattern
-pub static INT_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\d+(\.\d+)?$").unwrap());
+pub static INT_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[0-9]+(\.[0-9]+)?$").unwrap());
 
 /// RainDocument Namespace pattern
 pub static NAMESPACE_PATTERN: Lazy<Regex> =
@@ -76,7 +78,7 @@ pub static NON_EMPTY_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^\s]").un
 
 /// operand arguments pattern (literal + namespace + quoted namespace)
 pub static OPERAND_ARG_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^0x[0-9a-fA-F]+$|^\d+(\.\d+)?$|^[1-9]\d*(\.\d+)?e\d+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$|^'?\.?[a-z][0-9a-z-]*(\.[a-z][0-9a-z-]*)*$"#).unwrap()
+    Regex::new(r#"^0x[0-9a-fA-F]+$|^[0-9]+(\.[0-9]+)?$|^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$|^'?\.?[a-z][0-9a-z-]*(\.[a-z][0-9a-z-]*)*$"#).unwrap()
 });
 
 /// quote pattern

--- a/crates/dotrain/src/types/patterns.rs
+++ b/crates/dotrain/src/types/patterns.rs
@@ -23,7 +23,11 @@ pub static HASH_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]{
 
 /// numeric pattern
 pub static NUMERIC_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^0x[0-9a-fA-F]+$|^[0-9]+(\.[0-9]+)?$|^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$").unwrap()
+    Regex::new(
+        (HEX_PATTERN.as_str().to_string() + "|" + INT_PATTERN.as_str() + "|" + E_PATTERN.as_str())
+            .as_str(),
+    )
+    .unwrap()
 });
 
 /// string literal pattern
@@ -37,7 +41,16 @@ pub static SUB_PARSER_LITERAL_PATTERN: Lazy<Regex> =
 /// literal pattern (numeric + string literal + sub parser)
 pub static LITERAL_PATTERN: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r#"^0x[0-9a-fA-F]+$|^[0-9]+(\.[0-9]+)?$|^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$"#,
+        (HEX_PATTERN.as_str().to_string()
+            + "|"
+            + INT_PATTERN.as_str()
+            + "|"
+            + E_PATTERN.as_str()
+            + "|"
+            + STRING_LITERAL_PATTERN.as_str()
+            + "|"
+            + SUB_PARSER_LITERAL_PATTERN.as_str())
+        .as_str(),
     )
     .unwrap()
 });
@@ -78,7 +91,21 @@ pub static NON_EMPTY_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^\s]").un
 
 /// operand arguments pattern (literal + namespace + quoted namespace)
 pub static OPERAND_ARG_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^0x[0-9a-fA-F]+$|^[0-9]+(\.[0-9]+)?$|^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$|^'?\.?[a-z][0-9a-z-]*(\.[a-z][0-9a-z-]*)*$"#).unwrap()
+    Regex::new(
+        (HEX_PATTERN.as_str().to_string()
+            + "|"
+            + INT_PATTERN.as_str()
+            + "|"
+            + E_PATTERN.as_str()
+            + "|"
+            + STRING_LITERAL_PATTERN.as_str()
+            + "|"
+            + SUB_PARSER_LITERAL_PATTERN.as_str()
+            + "|"
+            + r#"^'?\.?[a-z][0-9a-z-]*(\.[a-z][0-9a-z-]*)*$"#)
+            .as_str(),
+    )
+    .unwrap()
 });
 
 /// quote pattern

--- a/crates/dotrain/src/types/patterns.rs
+++ b/crates/dotrain/src/types/patterns.rs
@@ -41,11 +41,7 @@ pub static SUB_PARSER_LITERAL_PATTERN: Lazy<Regex> =
 /// literal pattern (numeric + string literal + sub parser)
 pub static LITERAL_PATTERN: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        (HEX_PATTERN.as_str().to_string()
-            + "|"
-            + INT_PATTERN.as_str()
-            + "|"
-            + E_PATTERN.as_str()
+        (NUMERIC_PATTERN.as_str().to_string()
             + "|"
             + STRING_LITERAL_PATTERN.as_str()
             + "|"

--- a/crates/dotrain/src/types/patterns.rs
+++ b/crates/dotrain/src/types/patterns.rs
@@ -23,7 +23,7 @@ pub static HASH_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]{
 
 /// numeric pattern
 pub static NUMERIC_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]+$|^\d+$|^[1-9]\d*e\d+$").unwrap());
+    Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]+$|^\d+(\.\d+)?$|^[1-9]\d*(\.\d+)?e\d+$").unwrap());
 
 /// string literal pattern
 pub static STRING_LITERAL_PATTERN: Lazy<Regex> =
@@ -35,17 +35,20 @@ pub static SUB_PARSER_LITERAL_PATTERN: Lazy<Regex> =
 
 /// literal pattern (numeric + string literal + sub parser)
 pub static LITERAL_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^0x[0-9a-fA-F]+$|^\d+$|^[1-9]\d*e\d+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$"#).unwrap()
+    Regex::new(
+        r#"^0x[0-9a-fA-F]+$|^\d+(\.\d+)?$|^[1-9]\d*(\.\d+)?e\d+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$"#,
+    )
+    .unwrap()
 });
 
 /// Hex pattern
 pub static HEX_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]+$").unwrap());
 
 /// e numberic pattern
-pub static E_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[1-9]\d*e\d+$").unwrap());
+pub static E_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[1-9]\d*(\.\d+)?e\d+$").unwrap());
 
 /// Integer pattern
-pub static INT_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\d+$").unwrap());
+pub static INT_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\d+(\.\d+)?$").unwrap());
 
 /// RainDocument Namespace pattern
 pub static NAMESPACE_PATTERN: Lazy<Regex> =
@@ -73,7 +76,7 @@ pub static NON_EMPTY_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^\s]").un
 
 /// operand arguments pattern (literal + namespace + quoted namespace)
 pub static OPERAND_ARG_PATTERN: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^0x[0-9a-fA-F]+$|^\d+$|^[1-9]\d*e\d+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$|^'?\.?[a-z][0-9a-z-]*(\.[a-z][0-9a-z-]*)*$"#).unwrap()
+    Regex::new(r#"^0x[0-9a-fA-F]+$|^\d+(\.\d+)?$|^[1-9]\d*(\.\d+)?e\d+$|^\"[\s\S]*?\"$|^\[[\s\S]*?\]$|^'?\.?[a-z][0-9a-z-]*(\.[a-z][0-9a-z-]*)*$"#).unwrap()
 });
 
 /// quote pattern
@@ -191,7 +194,7 @@ mod tests {
             assert!(!INT_PATTERN.is_match(i), "String '{}' considered valid.", i);
         }
         // valids
-        for i in ["123", "1234567890", "83276401"] {
+        for i in ["123", "1234567890", "83276401", "123.123"] {
             assert!(
                 INT_PATTERN.is_match(i),
                 "String '{}' considered invalid.",
@@ -204,7 +207,7 @@ mod tests {
             assert!(!E_PATTERN.is_match(i), "String '{}' considered valid.", i);
         }
         // valids
-        for i in ["3e16", "2345e12987234", "101e1001"] {
+        for i in ["3e16", "2345e12987234", "101e1001", "123.45e12"] {
             assert!(E_PATTERN.is_match(i), "String '{}' considered invalid.", i);
         }
 
@@ -297,6 +300,8 @@ mod tests {
             "0x123abcdefAdfe",
             "'abcd12-jh2.oiu.lkj89-",
             "'.asd12-wer.jh45-iu78.lk9",
+            "123.123",
+            "123.12e2",
         ] {
             assert!(
                 OPERAND_ARG_PATTERN.is_match(i),

--- a/crates/dotrain/src/types/patterns.rs
+++ b/crates/dotrain/src/types/patterns.rs
@@ -125,7 +125,8 @@ pub static SUB_SOURCE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(",").unwrap
 pub static ANY_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"\S+").unwrap());
 
 /// rainlang lhs pattern
-pub static LHS_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-z][a-z0-9-]*$|^_$").unwrap());
+pub static LHS_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new((WORD_PATTERN.as_str().to_string() + "|" + "^_$").as_str()).unwrap());
 
 /// pragma pattern (keyword + ws + hex)
 pub static PRAGMA_PATTERN: Lazy<Regex> =

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -142,7 +142,7 @@ _: .r`;
         const _ns = _dotrain.namespace;
         const items: CompletionItem[] = [];
         _ns.forEach((v, k) => {
-            items.push({
+            items.unshift({
                 label: k,
                 kind: !("element" in v)
                     ? CompletionItemKind.Field

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -114,7 +114,7 @@ _: .`;
         const _ns = _dotrain.namespace;
         const items: CompletionItem[] = [];
         _ns.forEach((v, k) => {
-            items.push({
+            items.unshift({
                 label: k,
                 kind: !("element" in v)
                     ? CompletionItemKind.Field
@@ -142,7 +142,7 @@ _: .r`;
         const _ns = _dotrain.namespace;
         const items: CompletionItem[] = [];
         _ns.forEach((v, k) => {
-            items.unshift({
+            items.push({
                 label: k,
                 kind: !("element" in v)
                     ? CompletionItemKind.Field

--- a/test/diagnostic.test.ts
+++ b/test/diagnostic.test.ts
@@ -176,22 +176,6 @@ describe("LSP Diagnostics Language Service Tests", async function () {
         );
     });
 
-    it("should error: value greater than 32 bytes in size", async () => {
-        await testDiagnostics(
-            rainlang`${ws} #exn _: int-add(1 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);`,
-            services,
-            [
-                {
-                    message: "value out of range",
-                    range: toRange(0, 86, 0, 154),
-                    severity: DiagnosticSeverity.Error,
-                    code: ErrorCode.OutOfRangeValue,
-                    source: "rainlang",
-                },
-            ],
-        );
-    });
-
     it("should error: undefined word: max-uint266", async () => {
         await testDiagnostics(rainlang`${ws} #exn x: max-uint266;`, services, [
             {


### PR DESCRIPTION
## Motivation

updates dotrain to support decimal literals instead of int
resolves #121 

## Solution

Update the regexes for decimal literals

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
