### PR TITLE
support negative pow for e nuts

### DIFF
--- a/crates/dotrain/src/composer/mod.rs
+++ b/crates/dotrain/src/composer/mod.rs
@@ -1163,6 +1163,21 @@ _some-lhs-word: opcode-1(12 _bad-binding-name);
         ]));
         assert_eq!(result, expected_err);
 
+        let dotrain_text = r#"
+        some 
+        front 
+        matter
+---
+/* this is test */
+
+#exp-binding
+_: opcode-1(12.34e-6 1.234e-15);
+"#;
+        let rainlang_text = RainDocument::compose_text(dotrain_text, &["exp-binding"], None, None)?;
+        let expected_rainlang = r#"/* 0. exp-binding */ 
+_: opcode-1(12.34e-6 1.234e-15);"#;
+        assert_eq!(rainlang_text, expected_rainlang);
+
         Ok(())
     }
 

--- a/crates/dotrain/src/parser/rainlangdocument/mod.rs
+++ b/crates/dotrain/src/parser/rainlangdocument/mod.rs
@@ -429,6 +429,40 @@ mod tests {
         assert_eq!(consumed_count, exp.len());
         assert_eq!(op, expected_op);
 
+        let exp = r#"<2e-5 2.5e-6>"#;
+        let mut op = get_op();
+        let consumed_count = rl.process_operand(exp, 8, &mut op, &namespace);
+        let expected_op = Opcode {
+            opcode: get_op_details(),
+            operand: None,
+            output: None,
+            position: [5, 0],
+            parens: [0, 0],
+            inputs: vec![],
+            lhs_alias: None,
+            operand_args: Some(OperandArg {
+                position: [8, 21],
+                args: vec![
+                    OperandArgItem {
+                        value: Some("2e-5".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [9, 13],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                    OperandArgItem {
+                        value: Some("2.5e-6".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [14, 20],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                ],
+            }),
+        };
+        assert_eq!(consumed_count, exp.len());
+        assert_eq!(op, expected_op);
+
         Ok(())
     }
 
@@ -625,6 +659,47 @@ mod tests {
         assert_eq!(
             consumed_count,
             "another-opcode-2<\n  0x1f\n  87.3e2>(".len()
+        );
+        assert_eq!(rl.state.nodes, expected_state_nodes);
+
+        let text = "another-opcode-2<\n  0x1f\n  8.3e-2>(\n  0xabcef1234\n)";
+        rl.state.depth -= 1;
+        let consumed_count = rl.consume(text, 77, &namespace, &authoring_meta)?;
+        expected_state_nodes.push(Node::Opcode(Opcode {
+            opcode: OpcodeDetails {
+                name: "another-opcode-2".to_owned(),
+                description: String::new(),
+                position: [77, 93],
+            },
+            operand: None,
+            output: None,
+            position: [77, 0],
+            parens: [111, 0],
+            inputs: vec![],
+            lhs_alias: None,
+            operand_args: Some(OperandArg {
+                position: [93, 111],
+                args: vec![
+                    OperandArgItem {
+                        value: Some("0x1f".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [97, 101],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                    OperandArgItem {
+                        value: Some("8.3e-2".to_owned()),
+                        name: "operand arg".to_owned(),
+                        position: [104, 110],
+                        description: String::new(),
+                        binding_id: None,
+                    },
+                ],
+            }),
+        }));
+        assert_eq!(
+            consumed_count,
+            "another-opcode-2<\n  0x1f\n  8.3e-2>(".len()
         );
         assert_eq!(rl.state.nodes, expected_state_nodes);
 

--- a/crates/dotrain/src/types/patterns.rs
+++ b/crates/dotrain/src/types/patterns.rs
@@ -56,7 +56,7 @@ pub static HEX_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0x[0-9a-fA-F]+$
 
 /// e numberic pattern
 pub static E_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[1-9][0-9]*(\.[0-9]+)?e[0-9]+$").unwrap());
+    Lazy::new(|| Regex::new(r"^[1-9][0-9]*(\.[0-9]+)?e-?[0-9]+$").unwrap());
 
 /// Integer pattern
 pub static INT_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[0-9]+(\.[0-9]+)?$").unwrap());
@@ -238,7 +238,13 @@ mod tests {
             assert!(!E_PATTERN.is_match(i), "String '{}' considered valid.", i);
         }
         // valids
-        for i in ["3e16", "2345e12987234", "101e1001", "123.45e12"] {
+        for i in [
+            "3e16",
+            "2345e12987234",
+            "101e1001",
+            "123.45e12",
+            "123.45e-12",
+        ] {
             assert!(E_PATTERN.is_match(i), "String '{}' considered invalid.", i);
         }
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
resolves #127 
support negative pow e nums, such as 1.2e-12
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
update regex
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
