### PR TITLE
fix npm install script

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -46,20 +46,20 @@ jobs:
           node-version: 21
           cache: 'npm'
 
-      - run: nix run .#rainix-rs-prelude
+      - run: nix develop -c rainix-rs-prelude
       
       - name: Run rainix-rs-test
-        run: nix run .#rainix-rs-test
+        run: nix develop -c rainix-rs-test
 
       - name: Build JS Bindings
-        run:  nix run .#build-js-bindings
+        run:  nix develop -c build-js-bindings
       
       - name: Run JS Tests
-        run:  nix run .#test-js-bindings
+        run:  nix develop -c test-js-bindings
 
       # set npm version to rust crate version
       - name: Set Version
-        run: echo "NEW_VERSION=$(nix develop .#js -c npm version $(node ./scripts/version.js) --no-git-tag-version)" >> $GITHUB_ENV
+        run: echo "NEW_VERSION=$(nix develop -c npm version $(node ./scripts/version.js) --no-git-tag-version)" >> $GITHUB_ENV
 
       # Commit changes and tag
       - name: Commit And Tag
@@ -79,7 +79,7 @@ jobs:
 
       # Create npm package tarball to put in release files
       - name: Create NPM Package Tarball
-        run: echo "NPM_PACKAGE=$(nix develop .#js -c npm pack --silent)" >> $GITHUB_ENV
+        run: echo "NPM_PACKAGE=$(nix develop -c npm pack --silent)" >> $GITHUB_ENV
 
       - name: Rename NPM Package Tarball
         run: mv ${{ env.NPM_PACKAGE }} dotrain_npm_package_${{ env.NEW_VERSION }}.tgz

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -7,13 +7,13 @@ on:
         required: true
         type: choice
         options:
-          - alpha       # Increase the alpha pre-version (x.y.z-alpha.M)
-          - beta        # Increase the beta pre-version (x.y.z-beta.M)
-          - patch       # Increase the patch version (x.y.z)
-          - minor       # Increase the minor version (x.y.0)
-          - major       # Increase the major version (x.0.0)
-          - release     # Remove the pre-version, ie remove alpha/beta/rc (x.y.z)
-          - rc          # Increase the rc pre-version (x.y.z-rc.M)
+          - alpha   # Increase the alpha pre-version (x.y.z-alpha.M)
+          - beta    # Increase the beta pre-version (x.y.z-beta.M)
+          - patch   # Increase the patch version (x.y.z)
+          - minor   # Increase the minor version (x.y.0)
+          - major   # Increase the major version (x.0.0)
+          - release # Remove the pre-version, ie remove alpha/beta/rc (x.y.z)
+          - rc      # Increase the rc pre-version (x.y.z-rc.M)
 
 jobs:
   release:
@@ -30,20 +30,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v4
       - uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - name: Git Config
-        run: |
-          git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
-          git config --global user.name "${{ secrets.CI_GIT_USER }}"
-
-      - name: Publish to crates.io
-        run: nix develop -c cargo release --no-confirm --execute --no-tag --workspace ${{ inputs.version-level }}
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Install NodeJS v21
+      - name: Install NodeJS v22
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 22
           cache: 'npm'
 
       - run: nix develop -c rainix-rs-prelude
@@ -56,6 +46,16 @@ jobs:
       
       - name: Run JS Tests
         run:  nix develop -c test-js-bindings
+
+      - name: Git Config
+        run: |
+          git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.CI_GIT_USER }}"
+
+      - name: Publish to crates.io
+        run: nix develop -c cargo release --no-confirm --execute --no-tag --workspace ${{ inputs.version-level }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       # set npm version to rust crate version
       - name: Set Version

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -20,16 +20,16 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v4
       - uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - run: nix run .#rainix-rs-prelude
+      - run: nix develop -c rainix-rs-prelude
 
       - name: Run ${{ matrix.task }}
-        run: nix run .#${{ matrix.task }}
+        run: nix develop -c ${{ matrix.task }}
 
       - name: Build JS Bindings
-        run:  nix run .#build-js-bindings
+        run:  nix develop -c build-js-bindings
       
       - name: Run JS Tests
-        run:  nix run .#test-js-bindings
+        run:  nix develop -c test-js-bindings
 
       - name: Test JS Doc Generation
-        run:  nix run .#js-bindings-docs
+        run:  nix develop -c js-bindings-docs

--- a/README.md
+++ b/README.md
@@ -171,17 +171,17 @@ Here is an example of a `rainconfig.json`:
 ## **Building JS/TS Bindings**
 From the root of this repo, simply run the following to build the js bindings:
 ```bash
-nix run .#build-js-bindings
+nix develop -c build-js-bindings
 ```
 
 This will build the rust library with `wasm32-unknown-unknown` target in release mode with `js-api` feature enabled and then generates bindings using `wasm-bindgen-cli` into `./dist` directory by encoding the wasm binary into a json as importing json is native in js/ts and eliminates the need for using fetch/fs operations when loading the wasm module.
 
 To generate js/ts documents:
 ```bash
-nix run .#js-bindings-docs
+nix develop -c js-bindings-docs
 ```
 
 To run tests:
 ```bash
-nix run .#test-js-bindings
+nix develop -c test-js-bindings
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
           packages.rainix-rs-test
           packages.rainix-rs-artifacts
         ];
-        nativeBuildInputs = [
+        buildInputs = [
           rainix.rust-toolchain.${system}
           rainix.rust-build-inputs.${system}
           rainix.node-build-inputs.${system}

--- a/flake.nix
+++ b/flake.nix
@@ -45,12 +45,6 @@
             npm install
             npm run build
           '';
-          additionalBuildInputs = [
-            pkgs.wasm-bindgen-cli
-            rainix.rust-toolchain.${system}
-            rainix.rust-build-inputs.${system}
-            rainix.node-build-inputs.${system}
-          ];
         };
 
         test-js-bindings = rainix.mkTask.${system} {
@@ -59,9 +53,6 @@
             set -euxo pipefail
             npm test
           '';
-          additionalBuildInputs = [
-            rainix.node-build-inputs.${system}
-          ];
         };
 
         js-bindings-docs = rainix.mkTask.${system} {
@@ -70,9 +61,6 @@
             set -euxo pipefail
             npm run docgen
           '';
-          additionalBuildInputs = [
-            rainix.node-build-inputs.${system}
-          ];
         };
       } // rainix.packages.${system};
 
@@ -80,17 +68,15 @@
       defaultPackage = packages.build-bin;
 
       # For `nix develop`:
-      devShells = {
-        js = pkgs.mkShell {
-          nativeBuildInputs = [
-            rainix.rust-toolchain.${system}
-            rainix.rust-build-inputs.${system}
-            rainix.node-build-inputs.${system}
-          ] ++ (with pkgs; [ 
-            wasm-bindgen-cli
-          ]);
-        };
-      } // rainix.devShells.${system};
+      devShells.default = pkgs.mkShell {
+        packages = [
+          packages.build-js-bindings
+          packages.test-js-bindings
+          packages.js-bindings-docs
+        ];
+        buildInputs = rainix.devShells.${system}.default.buildInputs;
+        nativeBuildInputs = rainix.devShells.${system}.default.nativeBuildInputs;
+      };
     }
   );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,10 @@
           packages.build-js-bindings
           packages.test-js-bindings
           packages.js-bindings-docs
+          packages.rainix-rs-prelude
+          packages.rainix-rs-static
+          packages.rainix-rs-test
+          packages.rainix-rs-artifacts
         ];
         buildInputs = rainix.devShells.${system}.default.buildInputs;
         nativeBuildInputs = rainix.devShells.${system}.default.nativeBuildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -78,11 +78,8 @@
           packages.rainix-rs-test
           packages.rainix-rs-artifacts
         ];
-        buildInputs = [
-          rainix.rust-toolchain.${system}
-          rainix.rust-build-inputs.${system}
-          rainix.node-build-inputs.${system}
-        ] ++ (with pkgs; [ 
+        buildInputs = rainix.devShells.${system}.default.buildInputs;
+        nativeBuildInputs = rainix.devShells.${system}.default.nativeBuildInputs ++ (with pkgs; [ 
           wasm-bindgen-cli
         ]);
       };

--- a/flake.nix
+++ b/flake.nix
@@ -78,8 +78,13 @@
           packages.rainix-rs-test
           packages.rainix-rs-artifacts
         ];
-        buildInputs = rainix.devShells.${system}.default.buildInputs;
-        nativeBuildInputs = rainix.devShells.${system}.default.nativeBuildInputs;
+        nativeBuildInputs = [
+          rainix.rust-toolchain.${system}
+          rainix.rust-build-inputs.${system}
+          rainix.node-build-inputs.${system}
+        ] ++ (with pkgs; [ 
+          wasm-bindgen-cli
+        ]);
       };
     }
   );

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           body = ''
             set -euxo pipefail
             npm install
+            npm run build
           '';
           additionalBuildInputs = [
             pkgs.wasm-bindgen-cli

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
         "/example.rainconfig.json"
     ],
     "scripts": {
-        "prepack": "npm run build",
-        "build": "rimraf ./dist && npm run build-wasm && npm run build-bindings && npm run lint-bindings",
+        "prepublish": "node scripts/build check",
+        "prepublishOnly": "npm run build",
+        "build": "rimraf ./dist && nix-develop -c npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",
         "web-bg": "wasm-bindgen --target web ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/web",
@@ -42,7 +43,8 @@
         "lint": "eslint \"dist/**\" \"test/**\"",
         "lint-fix": "eslint \"dist/**\" \"test/**\" --fix",
         "docgen": "rimraf ./docs && api-extractor run --local && api-documenter -i ./ -o ./docs && npm run move-api",
-        "move-api": "copyfiles \"./dotrain.api.json\" \"./docs\" && rimraf ./dotrain.api.json && rimraf ./dist/cjs/tsdoc-metadata.json"
+        "move-api": "copyfiles \"./dotrain.api.json\" \"./docs\" && rimraf ./dotrain.api.json && rimraf ./dist/cjs/tsdoc-metadata.json",
+        "rm-dist": "rimraf ./dist"
     },
     "devDependencies": {
         "@microsoft/api-extractor": "^7.33.5",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     ],
     "scripts": {
         "prepublish": "node scripts/build check",
-        "prepublishOnly": "npm run nix-build",
-        "nix-build": "rimraf ./dist && nix develop -c npm run build",
+        "nix-build": "nix develop -c npm run build",
         "build": "npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "/example.rainconfig.json"
     ],
     "scripts": {
-        "prepack": "npm run build",
+        "preinstall": "npm run build",
         "build": "rimraf ./dist && npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "scripts": {
         "prepublish": "node scripts/build check",
         "prepublishOnly": "npm run build",
-        "build": "rimraf ./dist && nix-develop -c npm run build-wasm && npm run build-bindings && npm run lint-bindings",
+        "build": "rimraf ./dist && nix develop -c npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",
         "web-bg": "wasm-bindgen --target web ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/web",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     ],
     "scripts": {
         "prepublish": "node scripts/build check",
-        "prepublishOnly": "npm run build",
-        "build": "rimraf ./dist && nix develop -c npm run build-wasm && npm run build-bindings && npm run lint-bindings",
+        "prepublishOnly": "npm run nix-build",
+        "nix-build": "rimraf ./dist && nix develop -c npm run build",
+        "build": "npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",
         "web-bg": "wasm-bindgen --target web ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/web",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "/example.rainconfig.json"
     ],
     "scripts": {
-        "prepublish": "npm run build",
+        "prepack": "npm run build",
         "build": "rimraf ./dist && npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "/example.rainconfig.json"
     ],
     "scripts": {
-        "preinstall": "npm run build",
+        "prepack": "npm run build",
         "build": "rimraf ./dist && npm run build-wasm && npm run build-bindings && npm run lint-bindings",
         "build-wasm": "cargo build --target wasm32-unknown-unknown --lib --features 'js-api' -r",
         "node-bg": "wasm-bindgen --target nodejs ./target/wasm32-unknown-unknown/release/dotrain_lsp.wasm --out-dir ./temp/node",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const args = process.argv.slice(2);
+
+if (args[0] === "check") {
+    if (fs.existsSync("./dist")) return;
+}
+
+execSync("npm run rm-dist");
+execSync("npm run build");

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -4,8 +4,11 @@ const { execSync } = require("child_process");
 const args = process.argv.slice(2);
 
 if (args[0] === "check") {
+    // exit early if already built
+    // for npm install from an already built and packed package
     if (fs.existsSync("./dist")) return;
 }
 
+console.log("building wasm...");
 execSync("npm run rm-dist");
-execSync("npm run build");
+execSync("npm run nix-build");


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
fixes issue with installing the js package from npm, that required some unused dependencies from rainix
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
fix the package.json `prepublish` hook to skip trying to build if the package is already built and packed (installing from npm) and to try build when the package is not already built (installing from git), this is done through a `./scripts/build.js` script which gets run on `prepublish` hook and checks if `./dist` directory exists or not.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
